### PR TITLE
efficientMimetypeStreamReading

### DIFF
--- a/fables/__init__.py
+++ b/fables/__init__.py
@@ -45,4 +45,4 @@ __all__ = [
 ]
 
 # Note: When changing version also be sure to change the version in setup.py
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/fables/constants.py
+++ b/fables/constants.py
@@ -19,4 +19,4 @@ MAX_FILE_SIZE = 1024 ** 3  # bytes -> 1 GB
 # Number of bytes used to determine a mimetype from an io-stream. 30k was
 # found to accurately set mimetypes as a result of fables tests. User can
 # reset this var the same as MAX_FILE_SIZE.
-NUM_OF_BYTES_FOR_MIMETYPE = 30000
+NUM_BYTES_FOR_MIMETYPE_DETECTION = 30000

--- a/fables/constants.py
+++ b/fables/constants.py
@@ -15,3 +15,8 @@ OS_PATTERNS_TO_SKIP = [".DS_STORE", ".DS_Store", "__MACOSX"]
 >>> fables.detect('a_really_big_csv.csv')
 """
 MAX_FILE_SIZE = 1024 ** 3  # bytes -> 1 GB
+
+# Number of bytes used to determine a mimetype from an io-stream. 30k was
+# found to accurately set mimetypes as a result of fables tests. User can
+# reset this var the same as MAX_FILE_SIZE.
+NUM_OF_BYTES_FOR_MIMETYPE = 30000

--- a/fables/tree.py
+++ b/fables/tree.py
@@ -351,7 +351,7 @@ def mimetype_from_stream(stream: Optional[IO[bytes]]) -> Optional[str]:
     if stream is None:
         return None
 
-    mimebytes = stream.read(2048)
+    mimebytes = stream.read(30000)
     mimetype = magic.from_buffer(mimebytes, mime=True)
     stream.seek(0)
 

--- a/fables/tree.py
+++ b/fables/tree.py
@@ -18,7 +18,7 @@ import magic
 from msoffcrypto import OfficeFile  # type: ignore
 from msoffcrypto.__main__ import is_encrypted
 
-from fables.constants import OS_PATTERNS_TO_SKIP
+from fables.constants import OS_PATTERNS_TO_SKIP, NUM_OF_BYTES_FOR_MIMETYPE
 from fables.errors import ExtractError
 
 
@@ -351,7 +351,7 @@ def mimetype_from_stream(stream: Optional[IO[bytes]]) -> Optional[str]:
     if stream is None:
         return None
 
-    mimebytes = stream.read(30000)
+    mimebytes = stream.read(NUM_OF_BYTES_FOR_MIMETYPE)
     mimetype = magic.from_buffer(mimebytes, mime=True)
     stream.seek(0)
 

--- a/fables/tree.py
+++ b/fables/tree.py
@@ -351,7 +351,7 @@ def mimetype_from_stream(stream: Optional[IO[bytes]]) -> Optional[str]:
     if stream is None:
         return None
 
-    mimebytes = stream.read()
+    mimebytes = stream.read(2048)
     mimetype = magic.from_buffer(mimebytes, mime=True)
     stream.seek(0)
 

--- a/fables/tree.py
+++ b/fables/tree.py
@@ -18,7 +18,7 @@ import magic
 from msoffcrypto import OfficeFile  # type: ignore
 from msoffcrypto.__main__ import is_encrypted
 
-from fables.constants import OS_PATTERNS_TO_SKIP, NUM_OF_BYTES_FOR_MIMETYPE
+from fables.constants import OS_PATTERNS_TO_SKIP, NUM_BYTES_FOR_MIMETYPE_DETECTION
 from fables.errors import ExtractError
 
 
@@ -351,7 +351,7 @@ def mimetype_from_stream(stream: Optional[IO[bytes]]) -> Optional[str]:
     if stream is None:
         return None
 
-    mimebytes = stream.read(NUM_OF_BYTES_FOR_MIMETYPE)
+    mimebytes = stream.read(NUM_BYTES_FOR_MIMETYPE_DETECTION)
     mimetype = magic.from_buffer(mimebytes, mime=True)
     stream.seek(0)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 # Note: It would be nice to have a single source of truth for the version; (it exists here and in
 # fables/__init__.py). Here is a nice reference of different ways this can be achieved:
 # https://packaging.python.org/guides/single-sourcing-package-version/
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 
 
 with open("README.md") as f:


### PR DESCRIPTION
mimetype_from_stream only reads in the necessary first 2048 bytes for file identification (per https://pypi.org/project/python-magic/), updated version with minor change.

![Screen Shot 2020-12-01 at 7 56 40 AM](https://user-images.githubusercontent.com/75316166/100756805-d5d69980-33aa-11eb-87d7-8f5cc84c79c4.png)
