### PR TITLE
explicitly resetting io stream to start after pandas read.

### DIFF
--- a/fables/parse.py
+++ b/fables/parse.py
@@ -109,6 +109,7 @@ def parse_csv(
     except csv.Error:
         delimiter = ","
     df = pd.read_csv(bytesio, skip_blank_lines=True, sep=delimiter, **pandas_kwargs)
+    bytesio.seek(0)
     df = post_process_dataframe(df, force_numeric)
     return df
 


### PR DESCRIPTION
fixing broken assertion in list item 2 in issue #52 . This wont fix item 1 in #52, but it's a step closer to non-broken tests.

I ran `nox` and there are 2 broken tests instead of 3 after this update.