### PR TITLE
Move empty column trim before header check.

### DIFF
--- a/fables/__init__.py
+++ b/fables/__init__.py
@@ -45,4 +45,4 @@ __all__ = [
 ]
 
 # Note: When changing version also be sure to change the version in setup.py
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/fables/parse.py
+++ b/fables/parse.py
@@ -85,9 +85,9 @@ def remove_data_before_header(df: pd.DataFrame, force_numeric: bool) -> pd.DataF
 def post_process_dataframe(df: pd.DataFrame, force_numeric: bool) -> pd.DataFrame:
     # Remove columns that have no header and have only null data.
     for col in df.columns:
-        if (pd.isnull(col) or str(col).startswith("Unnamed: ")) and len(
-            df[col].value_counts()
-        ) == 0:
+        if (pd.isnull(col) or str(col).startswith("Unnamed: ")) and df[
+            col
+        ].isnull().all():
             df.drop(col, axis=1, inplace=True)
     # Remove data before headers.
     df = remove_data_before_header(df, force_numeric)

--- a/fables/parse.py
+++ b/fables/parse.py
@@ -83,6 +83,13 @@ def remove_data_before_header(df: pd.DataFrame, force_numeric: bool) -> pd.DataF
 
 
 def post_process_dataframe(df: pd.DataFrame, force_numeric: bool) -> pd.DataFrame:
+    # Remove columns that have no header and have only null data.
+    for col in df.columns:
+        if (pd.isnull(col) or str(col).startswith("Unnamed: ")) and len(
+            df[col].value_counts()
+        ) == 0:
+            df.drop(col, axis=1, inplace=True)
+    # Remove data before headers.
     df = remove_data_before_header(df, force_numeric)
     num_rows_before = len(df)
     if num_rows_before:
@@ -92,12 +99,6 @@ def post_process_dataframe(df: pd.DataFrame, force_numeric: bool) -> pd.DataFram
         num_rows_after = len(df)
         df.index = range(num_rows_after)
 
-        # Remove columns that have no header and have only null data.
-        for col in df.columns:
-            if (pd.isnull(col) or str(col).startswith("Unnamed: ")) and len(
-                df[col].value_counts()
-            ) == 0:
-                df.drop(col, axis=1, inplace=True)
     return df
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 # Note: It would be nice to have a single source of truth for the version; (it exists here and in
 # fables/__init__.py). Here is a nice reference of different ways this can be achieved:
 # https://packaging.python.org/guides/single-sourcing-package-version/
-VERSION = "1.2.1"
+VERSION = "1.2.2"
 
 
 with open("README.md") as f:

--- a/tests/integration/test_it_parses_files.py
+++ b/tests/integration/test_it_parses_files.py
@@ -558,7 +558,9 @@ def test_it_creates_a_parse_error_for_corrupt_file():
         "more_null_middle_cols_than_non_null_cols.xlsx",
     ],
 )
-def test_it_creates_a_parse_error_for_no_valid_headers(file_name):
+def test_it_removes_columns_that_have_no_headers_and_have_only_null_data_before_parsing(
+    file_name,
+):
     file_path = os.path.join(DATA_DIR, file_name)
 
     parse_results = list(fables.parse(io=file_path))
@@ -568,16 +570,16 @@ def test_it_creates_a_parse_error_for_no_valid_headers(file_name):
     assert parse_result.name == file_path
 
     tables = parse_result.tables
-    assert len(tables) == 0
+    assert len(tables) == 1
 
     errors = parse_result.errors
-    assert len(errors) == 1
+    assert len(errors) == 0
 
-    error = errors[0]
-    assert error.name == file_path
-
-    assert error.exception_type is ValueError
-    assert "Error during pre-header row removal" in error.message
+    expected_df = pd.DataFrame(
+        columns=["this", "here's", "here's.1"],
+        data=[["that", "something", "some"], ["the other", "else", "other stuff"]],
+    )
+    pd.testing.assert_frame_equal(tables[0].df, expected_df, check_dtype=False)
 
 
 def test_it_parses_a_xls_with_no_extension():


### PR DESCRIPTION
Remove columns that have no header and have only null data before attempting to remove data before header.

Moving this logic up resolves an issue we are seeing with CSV files having extra trailing delimiters, causing fables to fail to parse the import.
