### PR TITLE
Fix/61 add clevercsv to instal dependencies

### DIFF
--- a/fables/__init__.py
+++ b/fables/__init__.py
@@ -45,4 +45,4 @@ __all__ = [
 ]
 
 # Note: When changing version also be sure to change the version in setup.py
-__version__ = "1.2.4"
+__version__ = "1.2.5"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 # Note: It would be nice to have a single source of truth for the version; (it exists here and in
 # fables/__init__.py). Here is a nice reference of different ways this can be achieved:
 # https://packaging.python.org/guides/single-sourcing-package-version/
-VERSION = "1.2.4"
+VERSION = "1.2.5"
 
 
 with open("README.md") as f:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,9 @@ setuptools.setup(
     ],
     install_requires=[
         "pandas==1.0.1",
+        "cchardet==2.1.7",
         "chardet==3.0.4",
+        "clevercsv==0.7.0",
         "python-magic==0.4.15",
         "xlrd==1.2.0",
         "msoffcrypto-tool==4.6.4",


### PR DESCRIPTION
I realized when I was updating the `fables` version in my other project that it wasn't automatically installing `fables`' dependencies (`cchardet` and `clevercsv`). I realize now that's due to the fact that those weren't specified in the install_requires in the `setup.py`. It does mean we have to keep versions consistent between `setup.py` and `requirements.txt`, but this way users won't have to specify additional dependencies in their own `requirements.txt` when using `fables`. Figured better to update now than later.